### PR TITLE
Fix: Extract SOAP URL from wsdl URL passed

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -185,7 +185,8 @@ func (c *Client) Do(req *Request) (res *Response, err error) {
 		return nil, err
 	}
 
-	b, err := p.doRequest(c.Definitions.Services[0].Ports[0].SoapAddresses[0].Location)
+	soapURL := c.wsdl[:len(c.wsdl)-5]
+	b, err := p.doRequest(soapURL)
 	if err != nil {
 		return nil, ErrorWithPayload{err, p.Payload}
 	}


### PR DESCRIPTION
Extract SOAP URL from wsdl URL because the URL present in WSDL might not be the same and many times we dont have control over it. It might happen that the WSDL URL could be https but in wsdl definition, it could start with http. Calling https URL with http will give error below:

Expected element type <Envelope> but have <html>